### PR TITLE
fix: correct treesitter query.get_matches param

### DIFF
--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -75,7 +75,7 @@ local get_match_at_cursor = function()
     return range[3] == row - 1 and range[4] < col
   end
 
-  local matches = query.get_matches(0, 'injections')
+  local matches = query.get_matches(vim.api.nvim_get_current_buf(), 'injections')
   local before_cursor = {}
   local after_cursor = {}
   for _, match in ipairs(matches) do


### PR DESCRIPTION
Treesitter's `get_matches` uses current buffer when the first param is `nil` but not `0`

```lua
-- Copy from nvim-treesitter source code
function M.get_matches(bufnr, query_group)
  bufnr = bufnr or api.nvim_get_current_buf()
end
```