### PR TITLE
Clean temp file automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ require('femaco').setup({
   post_open_float = function(winnr)
     vim.wo.signcolumn = 'no'
   end
-  -- create the path to a temporary file
+  -- create the path to a temporary file, which will clear automatically
   create_tmp_filepath = function(filetype)
     return os.tmpname()
   end,

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -168,7 +168,8 @@ M.edit_code_block = function()
   }))
 
   local filetype = settings.ft_from_lang(match_data.lang)
-  vim.cmd('file ' .. settings.create_tmp_filepath(filetype))
+  local tempfile = settings.create_tmp_filepath(filetype)
+  vim.cmd('file ' .. tempfile)
   vim.bo.filetype = filetype
   vim.api.nvim_buf_set_lines(vim.fn.bufnr(), 0, -1, true, match_lines)
   -- use nvim_exec to do this silently
@@ -181,7 +182,7 @@ M.edit_code_block = function()
     buffer = 0,
     callback = function()
       local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, true)
-
+      vim.loop.fs_unlink(tempfile)
       if tbl_equal(match_lines, lines) then return end
 
       if lines[#lines] ~= '' and settings.ensure_newline(base_filetype) then


### PR DESCRIPTION
Regarding to https://github.com/AckslD/nvim-FeMaco.lua/issues/29

* Call `vim.loop.fs_unlink` to clean temp file. 
* Add little description for `create_tmp_filepath` 