### PR TITLE
Add normalize_indent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ require('femaco').setup({
   ensure_newline = function(base_filetype)
     return false
   end,
+  -- Return true if the indentation should be normalized. Useful when the
+  -- injected language inherits indentation from the construction scope (e.g. an
+  -- inline multiline sql string). If true, the leading indentation is detected,
+  -- stripped, and restored before/after editing.
+  --
+  -- @param base_filetype: The filetype which FeMaco is called from, not the
+  -- filetype of the injected language (this is the current buffer, so you can
+  -- get it from vim.bo.filetype).
+  normalize_indent = function (base_filetype)
+    return false
+  end
 })
 ```
 

--- a/lua/femaco/config.lua
+++ b/lua/femaco/config.lua
@@ -50,6 +50,17 @@ M.settings = {
   ensure_newline = function(base_filetype)
     return false
   end,
+  -- Return true if the indentation should be normalized. Useful when the
+  -- injected language inherits indentation from the construction scope (e.g. an
+  -- inline multiline sql string). If true, the leading indentation is detected,
+  -- stripped, and restored before/after editing.
+  --
+  -- @param base_filetype: The filetype which FeMaco is called from, not the
+  -- filetype of the injected language (this is the current buffer, so you can
+  -- get it from vim.bo.filetype).
+  normalize_indent = function (base_filetype)
+    return false
+  end
 }
 
 return M

--- a/lua/femaco/config.lua
+++ b/lua/femaco/config.lua
@@ -53,7 +53,7 @@ M.settings = {
   -- Return true if the indentation should be normalized. Useful when the
   -- injected language inherits indentation from the construction scope (e.g. an
   -- inline multiline sql string). If true, the leading indentation is detected,
-  -- stripped, and restored before/after editing.
+  -- and removed during editing, and re-added when the buffer is written.
   --
   -- @param base_filetype: The filetype which FeMaco is called from, not the
   -- filetype of the injected language (this is the current buffer, so you can

--- a/lua/femaco/config.lua
+++ b/lua/femaco/config.lua
@@ -45,8 +45,8 @@ M.settings = {
   -- if a newline should always be used, useful for multiline injections
   -- which separators needs to be on separate lines such as markdown, neorg etc
   -- @param base_filetype: The filetype which FeMaco is called from, not the
-  -- filetype of the injected language (this is the current buffer so you can
-  -- get it from vim.bo.filetyp).
+  -- filetype of the injected language (this is the current buffer, so you can
+  -- get it from vim.bo.filetype).
   ensure_newline = function(base_filetype)
     return false
   end,

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -279,9 +279,7 @@ M.edit_code_block = function()
   local should_normalize_indent = settings.normalize_indent(base_filetype)
   if should_normalize_indent then
     indent_sizes = get_ident_sizes(match_lines)
-    if indent_sizes.indent_size > 0 then
-      lines_for_edit, indent_char = un_indent_lines(match_lines, indent_sizes)
-    end
+    lines_for_edit, indent_char = un_indent_lines(match_lines, indent_sizes)
   end
 
   -- NOTE that we do this before opening the float
@@ -316,7 +314,7 @@ M.edit_code_block = function()
         table.insert(lines, "")
       end
       local sr, sc, er, ec = unpack(range)
-      if should_normalize_indent and indent_char and indent_sizes and indent_sizes.indent_size > 0 then
+      if should_normalize_indent and indent_char and indent_sizes then
         lines = re_indent_lines(lines, indent_sizes, indent_char)
       end
       vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, lines)

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -149,6 +149,10 @@ local update_range = function(range, lines)
 end
 
 local tbl_equal = function(left_tbl, right_tbl)
+  if #left_tbl ~= #right_tbl then
+    return false
+  end
+
   local equal = true
   for k, v in pairs(right_tbl) do
     if left_tbl[k] ~= v then

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -1,13 +1,13 @@
 local ts = vim.treesitter
 local get_node_range = ts.get_node_range
 if ts.get_node_range == nil then
-  get_node_range = require('nvim-treesitter.ts_utils').get_node_range
+  get_node_range = require("nvim-treesitter.ts_utils").get_node_range
 end
-local query = require('nvim-treesitter.query')
+local query = require("nvim-treesitter.query")
 
-local any = require('femaco.utils').any
-local clip_val = require('femaco.utils').clip_val
-local settings = require('femaco.config').settings
+local any = require("femaco.utils").any
+local clip_val = require("femaco.utils").clip_val
+local settings = require("femaco.config").settings
 
 local M = {}
 
@@ -40,7 +40,7 @@ end
 
 local get_match_text = function(match, bufnr)
   local srow, scol, erow, ecol = get_match_range(match)
-  return table.concat(vim.api.nvim_buf_get_text(bufnr, srow, scol, erow, ecol, {}), '\n')
+  return table.concat(vim.api.nvim_buf_get_text(bufnr, srow, scol, erow, ecol, {}), "\n")
 end
 
 local parse_match = function(match)
@@ -55,11 +55,11 @@ local parse_match = function(match)
   end
   local lang
   local lang_range
-  if type(language) == 'string' then
+  if type(language) == "string" then
     lang = language
   else
     lang = get_match_text(language, 0)
-    lang_range = {get_match_range(language)}
+    lang_range = { get_match_range(language) }
   end
   local content = match.content or (match.injection and match.injection.content)
 
@@ -85,22 +85,22 @@ local get_match_at_cursor = function()
     return range[3] == row - 1 and range[4] < col
   end
 
-  local matches = query.get_matches(vim.api.nvim_get_current_buf(), 'injections')
+  local matches = query.get_matches(vim.api.nvim_get_current_buf(), "injections")
   local before_cursor = {}
   local after_cursor = {}
   for _, match in ipairs(matches) do
     local match_data = parse_match(match)
-    local content_range = {get_match_range(match_data.content)}
-    local ranges = {content_range}
+    local content_range = { get_match_range(match_data.content) }
+    local ranges = { content_range }
     if match_data.lang_range then
       table.insert(ranges, match_data.lang_range)
     end
     if any(contains_cursor, ranges) then
-      return {lang = match_data.lang, content = match_data.content, range = content_range}
+      return { lang = match_data.lang, content = match_data.content, range = content_range }
     elseif any(is_after_cursor, ranges) then
-      table.insert(after_cursor, {lang = match_data.lang, content = match_data.content, range = content_range})
+      table.insert(after_cursor, { lang = match_data.lang, content = match_data.content, range = content_range })
     elseif any(is_before_cursor, ranges) then
-      table.insert(before_cursor, {lang = match_data.lang, content = match_data.content, range = content_range})
+      table.insert(before_cursor, { lang = match_data.lang, content = match_data.content, range = content_range })
     end
   end
   if #after_cursor > 0 then
@@ -161,32 +161,52 @@ end
 
 -- Calculate the indent size based on the smallest indent
 -- if a line with non-whitespace characters.
-local calc_indent_size = function(lines)
-  local smallest_indent_size = nil
-  for _, line in ipairs(lines) do
-    if line:match('^%s*$') == nil then
-      local indent_size_line = #line:match('^%s*')
+local get_ident_sizes = function(lines)
+  local first_indent_size, last_indent_size, smallest_indent_size = nil, nil, nil
+  for i, line in ipairs(lines) do
+    local indent_size_line = #line:match("^%s*")
+    local is_whitespace_only_line = line:match("^%s*$") ~= nil
+    if is_whitespace_only_line and i == 1 then
+      first_indent_size = indent_size_line
+    elseif is_whitespace_only_line and i == #lines then
+      last_indent_size = indent_size_line
+    elseif not is_whitespace_only_line then
       if smallest_indent_size == nil or (indent_size_line < smallest_indent_size) then
         smallest_indent_size = indent_size_line
       end
     end
   end
-  if smallest_indent_size == nil then
-    return 0
+  local indent_size = 0
+  if smallest_indent_size ~= nil then
+    indent_size = smallest_indent_size
   end
-  return smallest_indent_size
+  return {
+    first_indent_size = first_indent_size,
+    last_indent_size = last_indent_size,
+    indent_size = indent_size,
+  }
 end
 
-local un_indent_lines = function(lines, indent_size)
-  local lines_out = {}
+-- Strips leading indent from lines, if present. First and last row is handled
+-- as special cases; they are removed entirely if the provided indent_sizes are
+-- a match for the respective line (rely on re_indent_lines to restore them).
+local un_indent_lines = function(lines, indent_sizes)
   local indent_char = nil
 
+  local lines_out, lines_out_len = {}, 0
+  local function push_line(line)
+    lines_out_len = lines_out_len + 1
+    lines_out[lines_out_len] = line
+  end
+
   for i, line in ipairs(lines) do
-    local leading_whitespace = line:match('^%s*')
-    if #leading_whitespace == #line then
-      -- Leave empty lines and lines with only whitespace as-is to avoid setting
-      -- whitespace where there shouldn't be any.
-      lines_out[i] = line
+    local leading_whitespace = line:match("^%s*")
+    local leading_whitespace_size = #leading_whitespace
+
+    if i == 1 and leading_whitespace_size == indent_sizes.first_indent_size then
+      -- strip line, rely on auto insert post-edit
+    elseif i == #lines and leading_whitespace_size == indent_sizes.last_indent_size then
+      -- strip line, rely on auto insert post-edit
     else
       if indent_char == nil then
         indent_char = leading_whitespace:sub(1, 1)
@@ -200,11 +220,10 @@ local un_indent_lines = function(lines, indent_size)
           return lines, nil
         end
       end
-
-      if #leading_whitespace >= indent_size then
-        lines_out[i] = line:sub(indent_size + 1)
+      if #leading_whitespace >= indent_sizes.indent_size then
+        push_line(line:sub(indent_sizes.indent_size + 1))
       else
-        lines_out[i] = line
+        push_line(line)
       end
     end
   end
@@ -212,16 +231,33 @@ local un_indent_lines = function(lines, indent_size)
   return lines_out, indent_char
 end
 
-local re_indent_lines = function(lines, indent_size, indent_char)
-  local lines_out = {}
-  local indent = string.rep(indent_char or ' ', indent_size)
-  for i, line in ipairs(lines) do
-    local is_whitespace_only = line:match("^%s*$") ~= nil
-    if is_whitespace_only then
-      lines_out[i] = line
+-- Inserts leading indent to lines. First and last row is handled in a special
+-- way; they are inserted with the provided first and last indent sizes,
+-- respectively. It is assumed that they were previously stripped before the
+-- content was edited, so we don't need to treat the edited first and last row
+-- in any special way.
+local re_indent_lines = function(lines, indent_sizes, indent_char)
+  local lines_out, lines_out_len = {}, 0
+  local function push_line(line)
+    lines_out_len = lines_out_len + 1
+    lines_out[lines_out_len] = line
+  end
+
+  local indent = string.rep(indent_char or " ", indent_sizes.indent_size)
+  -- Restore original first whitespace only line
+  if indent_sizes.first_indent_size then
+    push_line(string.rep(indent_char or " ", indent_sizes.first_indent_size))
+  end
+  for _, line in ipairs(lines) do
+    if #line == 0 then
+      push_line(line) -- let empty lines remain empty
     else
-      lines_out[i] = indent .. line
+      push_line(indent .. line)
     end
+  end
+  -- Restore original trailing whitespace only line
+  if indent_sizes.last_indent_size then
+    push_line(string.rep(indent_char or " ", indent_sizes.last_indent_size))
   end
   return lines_out
 end
@@ -233,37 +269,37 @@ M.edit_code_block = function()
   if match_data == nil then
     return
   end
-  local match_lines = vim.split(get_match_text(match_data.content, 0), '\n')
-  -- NOTE that we do this before opening the float
-  local float_cursor = get_float_cursor(match_data.range, match_lines)
-  local range = match_data.range
-  local winnr = settings.prepare_buffer(settings.float_opts({
-    range = range,
-    lines = match_lines,
-    lang = match_data.lang,
-  }))
-
+  local match_lines = vim.split(get_match_text(match_data.content, 0), "\n")
   local filetype = settings.ft_from_lang(match_data.lang)
-  vim.cmd('file ' .. settings.create_tmp_filepath(filetype))
-  vim.bo.filetype = filetype
-
-  local indent_size, lines_for_edit, indent_char = 0, match_lines, nil
+  local indent_sizes, lines_for_edit, indent_char = nil, match_lines, nil
   local should_normalize_indent = settings.normalize_indent(base_filetype)
   if should_normalize_indent then
-    indent_size = calc_indent_size(match_lines)
-    if indent_size > 0 then
-      lines_for_edit, indent_char = un_indent_lines(match_lines, indent_size)
+    indent_sizes = get_ident_sizes(match_lines)
+    if indent_sizes.indent_size > 0 then
+      lines_for_edit, indent_char = un_indent_lines(match_lines, indent_sizes)
     end
   end
 
+  -- NOTE that we do this before opening the float
+  local float_cursor = get_float_cursor(match_data.range, lines_for_edit)
+  local range = match_data.range
+  local winnr = settings.prepare_buffer(settings.float_opts({
+    range = range,
+    lines = lines_for_edit,
+    lang = match_data.lang,
+  }))
+
+  vim.cmd("file " .. settings.create_tmp_filepath(filetype))
+  vim.bo.filetype = filetype
+
   vim.api.nvim_buf_set_lines(vim.fn.bufnr(), 0, -1, true, lines_for_edit)
   -- use nvim_exec to do this silently
-  vim.api.nvim_exec('write!', true)
+  vim.api.nvim_exec("write!", true)
   vim.api.nvim_win_set_cursor(0, float_cursor)
   settings.post_open_float(winnr)
 
   local float_bufnr = vim.fn.bufnr()
-  vim.api.nvim_create_autocmd({'BufWritePost', 'WinClosed'}, {
+  vim.api.nvim_create_autocmd({ "BufWritePost", "WinClosed" }, {
     buffer = 0,
     callback = function()
       local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, true)
@@ -272,12 +308,12 @@ M.edit_code_block = function()
         return -- unmodified
       end
 
-      if lines[#lines] ~= '' and settings.ensure_newline(base_filetype) then
-        table.insert(lines, '')
+      if lines[#lines] ~= "" and settings.ensure_newline(base_filetype) then
+        table.insert(lines, "")
       end
       local sr, sc, er, ec = unpack(range)
-      if should_normalize_indent and indent_char and indent_size > 0 then
-        lines = re_indent_lines(lines, indent_size, indent_char)
+      if should_normalize_indent and indent_char and indent_sizes and indent_sizes.indent_size > 0 then
+        lines = re_indent_lines(lines, indent_sizes, indent_char)
       end
       vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, lines)
       update_range(range, lines)
@@ -285,12 +321,12 @@ M.edit_code_block = function()
   })
   -- make sure the buffer is deleted when we close the window
   -- useful if user has hidden set
-  vim.api.nvim_create_autocmd('BufHidden', {
+  vim.api.nvim_create_autocmd("BufHidden", {
     buffer = 0,
     callback = function()
       vim.schedule(function()
         if vim.api.nvim_buf_is_loaded(float_bufnr) then
-          vim.cmd(string.format('bdelete! %d', float_bufnr))
+          vim.cmd(string.format("bdelete! %d", float_bufnr))
         end
       end)
     end,


### PR DESCRIPTION
This PR adds an option to the plugin to normalize the indentation of the injected block during editing. This is useful since it allows for a nicer editing experience when editing strings that have injected languages, which inherit the parent indentation of the surrounding code. Perhaps, most importantly, it allows for formatters and such to respect the original indentation.

The canonical example would probably be SQL strings in program code (see test plan).

The indentation checking is rather primitive, but seems rather solid. At least for the test cases I've could think of. 

Functionality can be enabled in setup using `normalize_indent`, which takes a function with the same signature as `ensure_newline`. The default function returns false. Considered having it on by default, but the interaction with `ensure_newline` is a little finicky so opted to leave existing configurations working instead.


### Known quirks

There's a little bit of a mental juggle when the first row is missing indentation, since the "leading indentation" in that case is in fact 0. Adding a new line right under it in the editor will put it at 0 on the next line which causes a discrepancy in the visual alignment between the inline editor and the result.

E.g.

```ts
const mySql = `SELECT * from USERS`
```

Edit in FeMaco =>

```sql
SELECT * from USERS
-- add comment after
```

Result =>

```ts
const mySql = `SELECT * from USERS
-- add comment after`
```

I don't see a clear solution to this that doesn't require a vastly more complicated setup where we parse outside of the injected treesitter region. Also, it's what the plugin does currently, so it seems fine.


## Test plan

I used this test file to verify that the changes behave as I expected them to do. Also attached a little movie showcasing how I tested it. The video shows a subset of the file tested on for clarity.

The last part of the video shows applying a formatter to the injected block (sql formatter), which is the use case I was mostly after starting to work on this.

Also verified that tab could be handled by replacing all double spaces with tabs and did the same tests.


```ts
import { Knex } from "knex";

export async function up(knex: Knex): Promise<void> {
  // 1. Leading and trailing newline
  await knex.raw(`
    SELECT * from USERS
  `);

  // 2. Leading whitespace only
  await knex.raw(`    SELECT * from USERS`);

  // 3. Trailing newline only
  await knex.raw(`SELECT * from USERS
                 `);

  // 4. Here-doc styled multiline formatting
  await knex.raw(`

SELECT * from USERS

`);

  // 5. Using formatter inside injected string
  await knex.raw(`
    select * from users 
    where id in (select user_id from account_suspensions where active is true)
    order by created_at desc;
  `);
}
```

<a href="https://github.com/AckslD/nvim-FeMaco.lua/assets/151489/95de4b8e-a8d8-4f98-8668-e84f79efbd98">Video demo</a>
