### PR TITLE
Add post_close_float()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ require('femaco').setup({
   post_open_float = function(winnr)
     vim.wo.signcolumn = 'no'
   end
+  -- what to do after closing the float
+  post_close_float = function(tmp_filepath)
+    vim.loop.fs_unlink(tmp_filepath)
+  end,
   -- create the path to a temporary file
   create_tmp_filepath = function(filetype)
     return os.tmpname()

--- a/lua/femaco/config.lua
+++ b/lua/femaco/config.lua
@@ -42,6 +42,10 @@ M.settings = {
   create_tmp_filepath = function(filetype)
     return os.tmpname()
   end,
+  -- what to do after closing the float
+  post_close_float = function(tmp_filepath)
+    vim.loop.fs_unlink(tmp_filepath)
+  end,
   -- if a newline should always be used, useful for multiline injections
   -- which separators needs to be on separate lines such as markdown, neorg etc
   -- @param base_filetype: The filetype which FeMaco is called from, not the

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -336,7 +336,7 @@ M.edit_code_block = function()
       end
 
       if tbl_equal(lines_for_edit, lines) then
-        return
+        return -- unmodified
       end
 
       if lines[#lines] ~= "" and settings.ensure_newline(base_filetype) then

--- a/lua/femaco/edit.lua
+++ b/lua/femaco/edit.lua
@@ -331,10 +331,11 @@ M.edit_code_block = function()
     callback = function(event)
       local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, true)
 
+      if event.event == 'WinClosed' then
+        settings.post_close_float(tmp_filepath)
+      end
+
       if tbl_equal(lines_for_edit, lines) then
-        if event.event == 'WinClosed' then
-          settings.post_close_float(tmp_filepath)
-        end
         return
       end
 
@@ -348,9 +349,6 @@ M.edit_code_block = function()
       end
       vim.api.nvim_buf_set_text(bufnr, sr, sc, er, ec, lines)
       update_range(range, lines)
-      if event.event == 'WinClosed' then
-        settings.post_close_float(tmp_filepath)
-      end
     end,
   })
   -- make sure the buffer is deleted when we close the window


### PR DESCRIPTION
This PR adds a new configurable callback `post_close_float` (symmetrical to `post_open_float`), which can be assigned a function that takes the created tmp filepath as an argument.

The default implementation fs_unlinks the tempfile (automatically cleans it up). Introducing automatic file deletion is always a little scary, but since the current implementation overwrites the file content every time I can't think of a scenario where deleting it would be catastrophic.

Presumably this covers the intended changes from https://github.com/AckslD/nvim-FeMaco.lua/pull/31, albeit taking a slightly more general approach.

## Test plan

Configured the hook to print and fs_unlink the temp file and verified it got printed and unlinked (only on close, not on save).

```
    post_close_float = function(tmp_filepath)
      print("got " .. tmp_filepath)
      vim.loop.fs_unlink(tmp_filepath)
    end,
```

And set the default implementation to delete the temp file.